### PR TITLE
Add URLs that npm can read

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "name": "Mantas Miliukas",
     "email": "mantasm@wix.com"
   },
+  "homepage": "https://github.com/wix-incubator/mjml-react",
+  "bugs": "https://github.com/wix-incubator/mjml-react/issues",
   "main": "dist/src/index.js",
   "files": [
     "extensions.js",


### PR DESCRIPTION
The homepage URL is used on the public npm package to help direct folks back to the codebase.