### PR TITLE
A title can contain a node/nodes which render to a string

### DIFF
--- a/src/mjml-title.js
+++ b/src/mjml-title.js
@@ -1,12 +1,12 @@
 import React, {Component} from 'react';
-import {string} from 'prop-types';
+import {node} from 'prop-types';
 
 import {handleMjmlProps} from './utils';
 
 export class MjmlTitle extends Component {
 
   static propTypes = {
-    children: string.isRequired
+    children: node.isRequired
   }
 
   render() {


### PR DESCRIPTION
Stops a proptype warning when doing things like:

```
<MjmlTitle>{this.props.name} A Special Offer For You!</MjmlTitle>
```