### PR TITLE
Make MjmlTable children optional

### DIFF
--- a/src/mjml-table.js
+++ b/src/mjml-table.js
@@ -5,7 +5,7 @@ import {handleMjmlProps} from './utils';
 
 export class MjmlTable extends Component {
   static propTypes = {
-    children: node.isRequired
+    children: node
   };
 
   render() {


### PR DESCRIPTION
`MjmlTable` required children, but when it's used for defining defaults inside `MjmlAttributes` it has no children, thus it throws warnings.

btw, many thanks for this great library 🤘