### PR TITLE
Make MjmlSection children optional

### DIFF
--- a/src/mjml-section.js
+++ b/src/mjml-section.js
@@ -6,7 +6,7 @@ import {handleMjmlProps} from './utils';
 export class MjmlSection extends Component {
 
   static propTypes = {
-    children: node.isRequired
+    children: node
   }
 
   render() {


### PR DESCRIPTION
For `MjmlSection` I believe the children prop should be optional as well, as one could use `MjmlSection` purely for decorational purposes.

e.g. using it to display a border
```jsx
<MjmlSection
  background-color="lightcoral"
  padding="3px 0 0 0"
  border-radius="2px 2px 0px 0px"
/>
```