### PR TITLE
fix(mjml-social): handle new properties

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,9 @@ const handlers = {
   'padding-left': numberToPx,
   'font-size': numberToPx,
   'letter-spacing': numberToPx,
-  'line-height': numberToPx
+  'line-height': numberToPx,
+  'icon-padding': numberToPx,
+  'text-padding': numberToPx
 };
 
 export function handleMjmlProps(props) {


### PR DESCRIPTION
Hello,

Since `mjml@4.21` we can use `text-padding` & `icon-padding` on both `mjml-social` & `mjml-social-element`. We can already use them but I think it should be useful to add `numberToPx` handler to these properties.

I will try to add them to [typescript def](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mjml-react).

I'm not really used to contribute to open project, let me know if I made mistakes