### PR TITLE
Use updated `with-eyes` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "puppeteer": "^1.4.0",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
-    "with-eyes": "^1.1.3",
+    "with-eyes": "^2.0.3",
     "yoshi": "^2.1.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Needed in order to move all eyes tests to the new dedicated server.
The old server will be deprecated on Dec 10.

For more information, please refer to the email I sent to feds@wix.com, or see this slack thread:
https://wix.slack.com/archives/C056JMHJ5/p1570355783071600