### PR TITLE
Allow React v17, fix yoshi version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
     "chai": "~4.1.0",
     "mjml": "^4.6.3",
     "puppeteer": "^1.4.0",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0",
     "with-eyes": "^3.0.1",
-    "yoshi": "^4.186.0"
+    "yoshi": "^4.86.0"
   },
   "peerDependencies": {
     "mjml": "^4.1.2",
-    "react": "^16.4.0",
-    "react-dom": "^16.4.0"
+    "react": "^16.4.0 || ^17.0.0",
+    "react-dom": "^16.4.0 || ^17.0.0"
   },
   "yoshi": {
     "hmr": "auto"


### PR DESCRIPTION
Hi I started using this library for MJML rendering.

However I currently have React v17 installed locally already, and the current peer dependencies complain about mismatch. Looking through the code, I don't see any usage of breaking changes from v17 (which already had minimal tweaks).

So I'm opening this PR to allow React v17 and silence those errors. Also when installing/running tests locally, the yoshi version failed. Looking at available versions, that appears to a typo