### PR TITLE
Solution to unique key problem.

### DIFF
--- a/src/mjml-accordion-element.js
+++ b/src/mjml-accordion-element.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlAccordionElement extends Component {
   static propTypes = {
@@ -10,10 +10,6 @@ export class MjmlAccordionElement extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement(
-      'mj-accordion-element',
-      handleMjmlProps(rest),
-      children,
-    );
+    return createElement('mj-accordion-element', rest, children);
   }
 }

--- a/src/mjml-accordion-text.js
+++ b/src/mjml-accordion-text.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlAccordionText extends Component {
   static propTypes = {
@@ -10,10 +10,6 @@ export class MjmlAccordionText extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement(
-      'mj-accordion-text',
-      handleMjmlProps(rest),
-      children,
-    );
+    return createElement('mj-accordion-text', rest, children);
   }
 }

--- a/src/mjml-accordion-title.js
+++ b/src/mjml-accordion-title.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlAccordionTitle extends Component {
   static propTypes = {
@@ -10,10 +10,6 @@ export class MjmlAccordionTitle extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement(
-      'mj-accordion-title',
-      handleMjmlProps(rest),
-      children,
-    );
+    return createElement('mj-accordion-title', rest, children);
   }
 }

--- a/src/mjml-accordion.js
+++ b/src/mjml-accordion.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlAccordion extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlAccordion extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-accordion', handleMjmlProps(rest), children);
+    return createElement('mj-accordion', rest, children);
   }
 }

--- a/src/mjml-attributes.js
+++ b/src/mjml-attributes.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlAttributes extends Component {
   static propTypes = {
@@ -10,10 +10,6 @@ export class MjmlAttributes extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement(
-      'mj-attributes',
-      handleMjmlProps(rest),
-      children,
-    );
+    return createElement('mj-attributes', rest, children);
   }
 }

--- a/src/mjml-body.js
+++ b/src/mjml-body.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlBody extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlBody extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-body', handleMjmlProps(rest), children);
+    return createElement('mj-body', rest, children);
   }
 }

--- a/src/mjml-button.js
+++ b/src/mjml-button.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlButton extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlButton extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-button', handleMjmlProps(rest), children);
+    return createElement('mj-button', rest, children);
   }
 }

--- a/src/mjml-carousel.js
+++ b/src/mjml-carousel.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlCarousel extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlCarousel extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-carousel', handleMjmlProps(rest), children);
+    return createElement('mj-carousel', rest, children);
   }
 }

--- a/src/mjml-column.js
+++ b/src/mjml-column.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlColumn extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlColumn extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-column', handleMjmlProps(rest), children);
+    return createElement('mj-column', rest, children);
   }
 }

--- a/src/mjml-group.js
+++ b/src/mjml-group.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlGroup extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlGroup extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-group', handleMjmlProps(rest), children);
+    return createElement('mj-group', rest, children);
   }
 }

--- a/src/mjml-head.js
+++ b/src/mjml-head.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlHead extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlHead extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-head', handleMjmlProps(rest), children);
+    return createElement('mj-head', rest, children);
   }
 }

--- a/src/mjml-hero.js
+++ b/src/mjml-hero.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlHero extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlHero extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-hero', handleMjmlProps(rest), children);
+    return createElement('mj-hero', rest, children);
   }
 }

--- a/src/mjml-navbar-link.js
+++ b/src/mjml-navbar-link.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlNavbarLink extends Component {
   static propTypes = {
@@ -10,10 +10,6 @@ export class MjmlNavbarLink extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement(
-      'mj-navbar-link',
-      handleMjmlProps(rest),
-      children,
-    );
+    return createElement('mj-navbar-link', rest, children);
   }
 }

--- a/src/mjml-navbar.js
+++ b/src/mjml-navbar.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlNavbar extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlNavbar extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-navbar', handleMjmlProps(rest), children);
+    return createElement('mj-navbar', rest, children);
   }
 }

--- a/src/mjml-preview.js
+++ b/src/mjml-preview.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { string } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlPreview extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlPreview extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-preview', handleMjmlProps(rest), children);
+    return createElement('mj-preview', rest, children);
   }
 }

--- a/src/mjml-raw.js
+++ b/src/mjml-raw.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlRaw extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlRaw extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-raw', handleMjmlProps(rest), children);
+    return createElement('mj-raw', rest, children);
   }
 }

--- a/src/mjml-section.js
+++ b/src/mjml-section.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlSection extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlSection extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-section', handleMjmlProps(rest), children);
+    return createElement('mj-section', rest, children);
   }
 }

--- a/src/mjml-social-element.js
+++ b/src/mjml-social-element.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlSocialElement extends Component {
   static propTypes = {
@@ -10,10 +10,6 @@ export class MjmlSocialElement extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement(
-      'mj-social-element',
-      handleMjmlProps(rest),
-      children,
-    );
+    return createElement('mj-social-element', rest, children);
   }
 }

--- a/src/mjml-social.js
+++ b/src/mjml-social.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlSocial extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlSocial extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-social', handleMjmlProps(rest), children);
+    return createElement('mj-social', rest, children);
   }
 }

--- a/src/mjml-table.js
+++ b/src/mjml-table.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlTable extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlTable extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-table', handleMjmlProps(rest), children);
+    return createElement('mj-table', rest, children);
   }
 }

--- a/src/mjml-text.js
+++ b/src/mjml-text.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlText extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlText extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-text', handleMjmlProps(rest), children);
+    return createElement('mj-text', rest, children);
   }
 }

--- a/src/mjml-title.js
+++ b/src/mjml-title.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlTitle extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlTitle extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-title', handleMjmlProps(rest), children);
+    return createElement('mj-title', rest, children);
   }
 }

--- a/src/mjml-wrapper.js
+++ b/src/mjml-wrapper.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class MjmlWrapper extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class MjmlWrapper extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mj-wrapper', handleMjmlProps(rest), children);
+    return createElement('mj-wrapper', rest, children);
   }
 }

--- a/src/mjml.js
+++ b/src/mjml.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { node } from 'prop-types';
 
-import { handleMjmlProps } from './utils';
+import { createElement } from './utils/index';
 
 export class Mjml extends Component {
   static propTypes = {
@@ -10,6 +10,6 @@ export class Mjml extends Component {
 
   render() {
     const { children, ...rest } = this.props;
-    return React.createElement('mjml', handleMjmlProps(rest), children);
+    return createElement('mjml', rest, children);
   }
 }

--- a/src/utils/create-element.js
+++ b/src/utils/create-element.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { handleMjmlProps } from '../utils.js';
+
+export function createElement(name, rest, children) {
+  return Array.isArray(children)
+    ? React.createElement(name, handleMjmlProps(rest), ...children)
+    : React.createElement(name, handleMjmlProps(rest), children);
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,3 +4,4 @@ export { useHttps } from './use-https';
 export { toMobileFontSize } from './to-mobile-font-size';
 export { getTextAlign } from './get-text-align';
 export { addQueryParams } from './add-query-params';
+export { createElement } from './create-element';

--- a/src/utils/render-to-json.js
+++ b/src/utils/render-to-json.js
@@ -95,7 +95,7 @@ function toReactElement(element) {
   return React.createElement(
     element.type,
     element.props,
-    element.children.map((child) =>
+    ...element.children.map((child) =>
       typeof child === 'string' ? child : toReactElement(child),
     ),
   );


### PR DESCRIPTION
We have bunch of warnings in our code that looks like this:
```
Warning: Each child in a list should have a unique "key" prop.

Check the top-level render call using <u>. See https://reactjs.org/link/warning-keys for more information.
```

It looks like those warnings are coming from `mjml-react` because `children` are passed as third argument to `React.createElement`. This is most probably wrong. E.g.:

```js
const a = [1, 2];

function hello() {
  return (
    <div>
      {a.map((i) => (<span>{i}</span>))}
  	</div>
  );
}


function hello2() {
  return (
    <div>
      <span>1</span>
      <span>2</span>
  	</div>
  );
}
```

JSX is transformed differently for these two cases:

```js
const a = [1, 2];

function hello() {
  return /*#__PURE__*/React.createElement("div", null, a.map(i => /*#__PURE__*/React.createElement("span", null, i)));
}

function hello2() {
  return /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("span", null, "1"), /*#__PURE__*/React.createElement("span", null, "2"));
}
```

It seems, if `children` is passed as third argument when it is Array, then it is treated as result of `Array.map` and React issues warning about missing key.

This fix checks if `children` is Array and in case it is spreads is as arguments to `React.createElement`.