### PR TITLE
Do not strip invalid color values: Resolves issue #73

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -67,7 +67,7 @@ function handleColor(name, value) {
     }
     return value;
   }
-  return '';
+  return value;
 }
 
 function parseColor(value) {

--- a/test/mjml-tags.spec.js
+++ b/test/mjml-tags.spec.js
@@ -262,7 +262,7 @@ describe('mjml tags', () => {
       );
     });
 
-    it('should render empty color attribute with passed values', () => {
+    it('should render original value for invalid color values', () => {
       expect(
         renderToMjml(
           <tags.MjmlColumn
@@ -277,7 +277,7 @@ describe('mjml tags', () => {
           </tags.MjmlColumn>,
         ),
       ).to.equal(
-        '<mj-column inner-background-color="" background-color=""><mj-divider border-color="" container-background-color=""></mj-divider><mj-text color="">Content</mj-text></mj-column>',
+        '<mj-column inner-background-color="#fafafaf" background-color="brown sugar"><mj-divider border-color="#g6labc" container-background-color="rgb(255,2)"></mj-divider><mj-text color="rgba(255,0)">Content</mj-text></mj-column>',
       );
     });
   });


### PR DESCRIPTION
Currently when using templating values in color fields eg:
`color: {{myVariable}}`
yields
`color: `

This allows for templating variables to not be stripped