### PR TITLE
chore: allow react v18 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "peerDependencies": {
     "mjml": "^4.7.0",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "yoshi": {
     "hmr": "auto"


### PR DESCRIPTION
v18 is out, and by default npm complains about libraries like mjml-react that do not have v18 as an allowed peer-dependency.

To my knowledge, the only breaking change of v18 is concurrent rendering, which does not appear to impact this library at all.