### PR TITLE
Default to not minifying as that is deprecated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ function render(email, options = {}) {
   const defaults = {
     keepComments: false,
     beautify: false,
-    minify: true,
+    minify: false,
     validationLevel: 'strict',
   };
   return mjml2html(renderToMjml(email), { ...defaults, ...options });


### PR DESCRIPTION
per #58 the mjml minify option is deprecated.

#75 attempts to solve this by implementing minification within this project. I propose we just make the default option to not minify.  